### PR TITLE
docs: add Flair platform under products

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Collection of awesome [wagmi](https://github.com/tmm/wagmi)-related projects and
 - [SushiSwap](https://sushi.com) A community-built open-source ecosystem of all the DeFi tools you need 🍣🔱 [GitHub](https://github.com/sushiswap/sushiswap)
 - [midwit](https://midwit.vercel.app) An experiment for combining narrative with smart contracts.
 - [moonbirds](https://www.moonbirds.xyz)
+- [Flair](https://flair.finance) An open-source platform to build NFT projects with ready-made contracts, React SDK, and a handy dashboard.
 
 [GitHub Discussion with more projects ](https://github.com/tmm/wagmi/discussions/201)
 


### PR DESCRIPTION
## Description

Flair is a platform that offers [open-source contracts](https://github.com/0xflair/evm-contracts) and React SDK (based on wagmi) for NFT_based projects with features such as NFT Sales, NFT Staking, Revenue Sharing, Allowlists, Royalty Management, etc.

We're using wagmi extensively in our stack and have our React SDK fully open-sourced in https://github.com/0xflair/typescript-sdk

Our React SDK packages aim to be as unopinionated as possible, e.g. https://www.npmjs.com/package/@0xflair/react-openzeppelin

I'm also a sponsor of @tmm for his amazing work on wagmi :)

Feel free to close this PR if you don't think it's the right place to put a link to Flair platform, no hard feelins haha 🌷

## Additional Information

- [x] I read the [contributing docs](/tmm/awesome-wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: `aram.eth`
