### PR TITLE
chore: add vite-wagmi-starter template

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Collection of awesome [wagmi](https://github.com/tmm/wagmi)-related projects and
 - [web3-data-fetching](https://github.com/vercel/examples/tree/main/solutions/web3-data-fetching) from [vercel/examples](https://github.com/vercel/examples)
 - [web3-sessions](https://github.com/vercel/examples/tree/main/solutions/web3-sessions) from [vercel/examples](https://github.com/vercel/examples)
 - [create-web3-frontend](https://github.com/dhaiwat10/create-web3-frontend)
+- [vite-wagmi-starter](https://github.com/fisand/vite-wagmi-starter)
 
 ## Resources
 


### PR DESCRIPTION
## Description

Add [vite-wagmi-starter](https://github.com/fisand/vite-wagmi-starter), a public dapp template

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/awesome-wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
