### PR TITLE
chore: Add reference to Marble Wagmi Connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Collection of awesome [wagmi](https://github.com/wagmi-dev/wagmi)-related projec
 ### Connectors
 
 - [@gnosis.pm/safe-apps-wagmi](https://github.com/safe-global/safe-apps-sdk/tree/master/packages/safe-apps-wagmi) — Connector for [Gnosis Safe](https://gnosis-safe.io)
+- [Marble Wallet Connector](https://www.npmjs.com/package/@marblexyz/wagmi-connector) — Connector for [Marble](https://www.marblewallet.com)
 - [Dynamic Connector](https://www.npmjs.com/package/@dynamic-labs/wagmi-connector) — Connector for [Dynamic](https://www.dynamic.xyz)
 - [Ledger Live Wagmi Connector](https://www.npmjs.com/package/@ledgerhq/ledger-live-wagmi-connector) — Connector for [Ledger Live](https://www.ledger.com/ledger-live)
 - [wagmi-magic-connector](https://github.com/EveripediaNetwork/wagmi-magic-connector) — Connector for [Magic](https://magic.link)


### PR DESCRIPTION
## Description

Adds reference to the Marble Wagmi Connector: [Marble Wallet Connector](https://www.npmjs.com/package/@marblexyz/wagmi-connector)

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/awesome-wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: theodor.eth
