### PR TITLE
Add larskarbo/date-to-block to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Collection of awesome [wagmi](https://github.com/wagmi-dev/wagmi)-related projec
 
 - [@thirdweb-dev/react](https://github.com/thirdweb-dev/react) — thirdweb React SDK
 - [ConnectKit](https://docs.family.co/connectkit) — Connecting a wallet, made simple.
+- [date-to-block](https://github.com/larskarbo/date-to-block) - Get a block number from a date, using Viem
 - [RainbowKit](https://github.com/rainbow-me/rainbowkit) — The best way to connect a wallet 🌈 🧰
 - [rainbowkit-use-siwe-auth](https://github.com/random-bits-studio/rainbowkit-use-siwe-auth) — a [RainbowKit](https://www.rainbowkit.com) authentication adapter for [UseSIWE](https://github.com/random-bits-studio/use-siwe).
 - [ReservoirKit](https://docs.reservoir.tools/docs/reservoir-kit) - A developer toolkit for buying, selling and managing NFTs.


### PR DESCRIPTION
## Description

https://github.com/larskarbo/date-to-block is a library that uses a binary search algorithm and RPC calls to approximate a block number from a date.

This isn't wagmi-specific, but I thought it could be a good place to post it since we don't have an awesome list for Viem.

## Additional Information

- [X] I read the [contributing docs](/wagmi-dev/awesome-wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: larskarbo.eth
